### PR TITLE
Add TLS and Ingress

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,5 +1,5 @@
 kind: pipeline
-name: default
+name: test
 
 steps:
 - name: unit-test
@@ -16,6 +16,11 @@ steps:
     files:
     - coverage.out
 
+---
+kind: pipeline
+name: staging
+
+steps:
 - name: docker
   image: plugins/docker
   settings:
@@ -36,4 +41,39 @@ steps:
       from_secret: api_server
   commands:
   - "helm template chart --name staging --set namespace=staging > deploy.yaml"
-  - kubectl --token=$${TOKEN} --server=$${API_SERVER} --insecure-skip-tls-verify apply -f deploy.yaml 
+  - kubectl --token=$${TOKEN} --server=$${API_SERVER} --insecure-skip-tls-verify apply -f deploy.yaml
+
+trigger:
+  branch:
+  - development
+
+---
+kind: pipeline
+name: production
+
+steps:
+- name: docker
+  image: plugins/docker
+  settings:
+    repo: nsmith5/vgraas
+    autotag: true
+    force_tag: true
+    username: nsmith5
+    password:
+      from_secret: docker_password
+
+- name: production deployment
+  image: nsmith5/k8s:alpine
+  pull: true
+  environment:
+    TOKEN:
+      from_secret: kubernetes_token
+    API_SERVER:
+      from_secret: api_server
+  commands:
+  - "helm template --name vgrass-prod --set namespace=production,image.tag=${TAG},ingress.expose=true,ingress.host=vgraas.nfsmith.ca,ingress.email=letsencrypt@nfsmith.ca . > prod-deploy.yaml"
+  - kubectl --token=$${TOKEN} --server=$${API_SERVER} --insecure-skip-tls-verify apply -f prod-deploy.yaml
+
+trigger:
+  event:
+  - tag

--- a/chart/templates/certificate.yaml
+++ b/chart/templates/certificate.yaml
@@ -1,0 +1,21 @@
+{{ if .Values.ingress.expose }}
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: vgraas
+  namespace: {{ .Values.namespace }}
+spec:
+  secretName: vgraas-tls
+  issuerRef:
+    name: letsencrypt
+    kind: Issuer
+  commonName: {{ .Values.ingress.host }} # Used for SAN
+  dnsNames:
+  - {{ .Values.ingress.host }}
+  acme:
+    config:
+    - http01:
+        ingress: vgraas 
+      domains:
+      - {{ .Values.ingress.host }}
+{{ end }}

--- a/chart/templates/clusterissuer.yaml
+++ b/chart/templates/clusterissuer.yaml
@@ -1,0 +1,14 @@
+{{ if .Values.ingress.expose }}
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Issuer
+metadata:
+  name: letsencrypt
+  namespace: {{ .Values.namespace }}
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: {{ .Values.ingress.email }}
+    privateKeySecretRef:
+      name: letsencrypt-production
+    http01: {}
+{{ end }}

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -1,0 +1,20 @@
+{{ if .Values.ingress.expose }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: vgraas
+  namespace: {{ .Values.namespace }}
+spec:
+  tls:
+  - hosts:
+    - {{ .Values.ingress.host }}
+    secretName: vgraas-tls
+  rules:
+  - host: {{ .Values.ingress.host }}
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: vgraas
+          servicePort: http
+{{ end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,7 +1,10 @@
-replicaCount: 3
+replicaCount: 1
+
 image:
   tag: latest
+
 namespace: default
+
 resources:
   limits:
     cpu: 100m
@@ -9,3 +12,8 @@ resources:
   requests:
     cpu: 100m
     memory: 128Mi
+
+ingress:
+  host: example.com
+  expose: false           # If true, an ingress with TLS termination is created
+  email: bob@example.com  # Email for letsencrypt


### PR DESCRIPTION
This feature adds the ability to deploy the API to a cluster that has an ingress controller and certificate manager. An ingress with TLS termination will be created for the API if helm chart is deployed with `ingress.expose=true`. 

The CI/CD pipeline has also be updated to do exactly this when git tags are added. The production endpoint lives at https://vgraas.nfsmith.ca

Closes #9 and closes #8 