### PR TITLE
Fix issue with lock on ratelimiter

### DIFF
--- a/pkg/middleware/ratelimit.go
+++ b/pkg/middleware/ratelimit.go
@@ -48,13 +48,13 @@ func RateLimit(next http.Handler, r, b, method int) http.Handler {
 					delete(visitors, ip)
 				}
 			}
+			mtx.Unlock()
 		}
 	}()
 
 	addVisitor := func(ip string) *rate.Limiter {
 		limiter := rate.NewLimiter(rate.Limit(r), b)
 		mtx.Lock()
-
 		visitors[ip] = &visitor{limiter, time.Now()}
 		mtx.Unlock()
 		return limiter


### PR DESCRIPTION
The go routine that was cleaning up old entries in the IP map
wasn't unlocking when complete.

Closes #20 